### PR TITLE
Fix output to include min

### DIFF
--- a/rc_connectivity_check/checker.py
+++ b/rc_connectivity_check/checker.py
@@ -114,7 +114,7 @@ def print_results(hostname: str, results: List[TestResult]):
 
         print(f"  - {color(result.ip, Fore.YELLOW)}: {res}")
         print(
-            f"    Latencies (min/max/avg): {result.avg_latency*1000:.1f}ms / {result.max_latency*1000:.1f}ms / {result.avg_latency*1000:.1f}ms"
+            f"    Latencies (min/max/avg): {result.min_latency*1000:.1f}ms / {result.max_latency*1000:.1f}ms / {result.avg_latency*1000:.1f}ms"
         )
 
 


### PR DESCRIPTION
<!-- Thank you for contributing to Purchases! Before pressing the "Create Pull Request" button, please provide the following: -->

### Checklist
- [ ] If applicable, unit tests
- [ ] If applicable, create follow-up issues for native and hybrids

(I considered writing a test, but no existing framework exists)

### Motivation
Previous the output was "avg/max/avg", despite the description saying "min/max/avg".


### Description
This changes the output to correctly display the "min"