### PR TITLE
Add (assets|icons|fonts).pawwalls.com to check list

### DIFF
--- a/rc_connectivity_check/checker.py
+++ b/rc_connectivity_check/checker.py
@@ -14,7 +14,15 @@ import urllib3
 init(autoreset=True)
 
 # Define the hostnames
-hostnames = ["www.revenuecat.com", "app.revenuecat.com", "api.revenuecat.com", "api-cf.revenuecat.com"]
+hostnames = [
+    "www.revenuecat.com",
+    "app.revenuecat.com",
+    "api.revenuecat.com",
+    "api-cf.revenuecat.com",
+    "assets.pawwalls.com",
+    "fonts.pawwalls.com",
+    "icons.pawwalls.com",
+]
 
 
 # Function to resolve DNS and get all IPs


### PR DESCRIPTION
This adds the domains we use to serve Paywall assets to rc-connectivity-check. 

(Any other domains we may want to add here?)